### PR TITLE
Disallow paragraphs and use breaks on Enter instead

### DIFF
--- a/financial-tables.html
+++ b/financial-tables.html
@@ -24,10 +24,10 @@
       { title: 'Visually hidden text', inline: 'span', classes: 'visuallyhidden' },
     ],
     // only allow table elements, plus a few more useful inline elements
-    // -p = remove empty paragraphs, as there is always an annoying one at the end of the editor
     // br = if added, TinyMCE adds br's all over the place (but they don't get through to the source code to be copied), causing issues with marking of empty header cells
     // class: source-tableeditor = in case we need to do something in slimmer
-    valid_elements: 'table[class:financial-data source-tableeditor|id],caption,col,colgroup[span],thead,tbody,tfoot,tr[class],td[scope|colspan|rowspan|class],th[scope|colspan|rowspan|class],strong,span[class],abbr[title],br,-p',
+    valid_elements: 'table[class:financial-data source-tableeditor|id],caption,col,colgroup[span],thead,tbody,tfoot,tr[class],td[scope|colspan|rowspan|class],th[scope|colspan|rowspan|class],strong,span[class],abbr[title],br',
+    forced_root_block: false,
     table_grid: false,
     table_advtab: false,
     table_cell_advtab: false,

--- a/generic-tables.html
+++ b/generic-tables.html
@@ -21,10 +21,10 @@
       { title: 'Visually hidden text', inline: 'span', classes: 'visuallyhidden' },
     ],
     // only allow table elements, plus a few more useful inline elements
-    // -p = remove empty paragraphs, as there is always an annoying one at the end of the editor
     // br = if added, TinyMCE adds br's all over the place (but they don't get through to the source code to be copied), causing issues with marking of empty header cells
     // class: source-tableeditor = in case we need to do something in slimmer
-    valid_elements: 'table[class:source-tableeditor|id],caption,col,colgroup[span],thead,tbody,tfoot,tr[class],td[scope|colspan|rowspan|class],th[scope|colspan|rowspan|class],strong,span[class],abbr[title],br,-p',
+    valid_elements: 'table[class:source-tableeditor|id],caption,col,colgroup[span],thead,tbody,tfoot,tr[class],td[scope|colspan|rowspan|class],th[scope|colspan|rowspan|class],strong,span[class],abbr[title],br',
+    forced_root_block: false,
     table_grid: false,
     table_advtab: false,
     table_cell_advtab: false,


### PR DESCRIPTION
When content editors were using the table editor, they had trouble with paragraphs sneaking in and making cells look bad due to different font sizes.
This disallows paragraphs altogether as they shouldn't be used in a table anyway. See also https://www.tinymce.com/docs/configure/content-filtering/#forced_root_block