### PR TITLE
Freeze TinyMCE at 4.9.11

### DIFF
--- a/financial-tables.html
+++ b/financial-tables.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <title>Financial Table Editor</title>
   <meta name="robots" content="noindex,nofollow" />
-  <script src="https://cdn.tinymce.com/4/tinymce.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/tinymce/4.9.11/tinymce.min.js"></script>
   <script>tinymce.init({
     selector: 'textarea',
     content_css: ['base.css', 'generic-tables.css', 'financial-tables.css'],

--- a/generic-tables.html
+++ b/generic-tables.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <title>Generic Table Editor</title>
   <meta name="robots" content="noindex,nofollow" />
-  <script src="https://cdn.tinymce.com/4/tinymce.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/tinymce/4.9.11/tinymce.min.js"></script>
   <script>tinymce.init({
     selector: 'textarea',
     content_css: ['base.css', 'generic-tables.css'],


### PR DESCRIPTION
There is a warning in the table editor tool that access to TinyMCE will
expire on 25th February 2021. The solution recommended by Tiny is to
upgrade to v5 – unfortunately this requires that we create an account
and generate an API key which makes this upgrade more complicated than
we would like (we would need a solution to store the login credentials
and API key, so `govuk-secrets` would probably have to be involved)

This updates the script src to pull version `4.9.11` of Tiny  from the
Cloudflare CDN as it would appear that this is the latest working version
without the expiration warning. This should at least buy us some time
and allow users to continue using this tool beyond the 25th Feb
deadline.